### PR TITLE
[Fix/#4]: 상태바 style 및 건의하기 페이지 이슈 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,12 @@
       "dependencies": {
         "@react-navigation/native": "^7.0.14",
         "cocoapods": "^0.0.0",
-        "expo": "~52.0.36",
+        "expo": "^52.0.42",
         "expo-status-bar": "~2.0.1",
         "react": "18.3.1",
-        "react-native": "0.76.7",
-        "react-native-webview": "^13.13.2"
+        "react-native": "^0.76.8",
+        "react-native-safe-area-context": "^4.12.0",
+        "react-native-webview": "^13.12.5"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -30,9 +31,9 @@
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.1.1.tgz",
-      "integrity": "sha512-F2i3xdycesw78QCOBHmpTn7eaD2iNXGwB2gkfwxcOfBbeauYpr8RBSyJOkDrFtKtVRMclg8Sg3n1ip0ACyUuag==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.1.2.tgz",
+      "integrity": "sha512-N2NGsU5FLBhT8NZ+3l2YrzZSHITjNXNuDhC4iDiikv0IujaJ0Xc6xIxQZ/Ek3Cb+rgPjnLHYyJm11tInuJn+cw==",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       },
@@ -105,12 +106,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
-      "integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
       "dependencies": {
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -427,11 +428,11 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1992,13 +1993,13 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2023,15 +2024,15 @@
     },
     "node_modules/@babel/traverse--for-generate-function-map": {
       "name": "@babel/traverse",
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
-      "integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
-        "@babel/parser": "^7.26.9",
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/generator": "^7.27.0",
+        "@babel/parser": "^7.27.0",
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2040,9 +2041,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -2204,29 +2205,29 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "0.22.17",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.22.17.tgz",
-      "integrity": "sha512-4VOGWoCINIlsQKL0Pl0kQpSs2xAaEPobJ/3Q3xHdtJrBj4S3IHrOyn6mUvubs4A4YySjiyZjlc4UG6GGwxzSsg==",
+      "version": "0.22.23",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.22.23.tgz",
+      "integrity": "sha512-LXFKu2jnk9ClVD+kw0sJCQ89zei01wz2t4EJwc9P7EwYb8gabC8FtPyM/X7NIE5jtrnTLTUtjW5ovxQSBL7pJQ==",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
         "@babel/runtime": "^7.20.0",
         "@expo/code-signing-certificates": "^0.0.5",
-        "@expo/config": "~10.0.10",
-        "@expo/config-plugins": "~9.0.15",
+        "@expo/config": "~10.0.11",
+        "@expo/config-plugins": "~9.0.17",
         "@expo/devcert": "^1.1.2",
         "@expo/env": "~0.4.2",
         "@expo/image-utils": "^0.6.5",
         "@expo/json-file": "^9.0.2",
-        "@expo/metro-config": "~0.19.11",
+        "@expo/metro-config": "~0.19.12",
         "@expo/osascript": "^2.1.6",
         "@expo/package-manager": "^1.7.2",
         "@expo/plist": "^0.2.2",
-        "@expo/prebuild-config": "^8.0.28",
+        "@expo/prebuild-config": "^8.0.30",
         "@expo/rudder-sdk-node": "^1.1.1",
         "@expo/spawn-async": "^1.7.2",
         "@expo/ws-tunnel": "^1.0.1",
         "@expo/xcpretty": "^4.3.0",
-        "@react-native/dev-middleware": "0.76.7",
+        "@react-native/dev-middleware": "0.76.8",
         "@urql/core": "^5.0.6",
         "@urql/exchange-retry": "^1.3.0",
         "accepts": "^1.3.8",
@@ -2306,13 +2307,13 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "10.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-10.0.10.tgz",
-      "integrity": "sha512-wI9/iam3Irk99ADGM/FyD7YrrEibIZXR4huSZiU5zt9o3dASOKhqepiNJex4YPiktLfKhYrpSEJtwno1g0SrgA==",
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-10.0.11.tgz",
+      "integrity": "sha512-nociJ4zr/NmbVfMNe9j/+zRlt7wz/siISu7PjdWE4WE+elEGxWWxsGzltdJG0llzrM+khx8qUiFK5aiVcdMBww==",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~9.0.15",
-        "@expo/config-types": "^52.0.4",
+        "@expo/config-plugins": "~9.0.17",
+        "@expo/config-types": "^52.0.5",
         "@expo/json-file": "^9.0.2",
         "deepmerge": "^4.3.1",
         "getenv": "^1.0.0",
@@ -2326,13 +2327,13 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "9.0.15",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-9.0.15.tgz",
-      "integrity": "sha512-elKY/zIpAJ40RH26iwfyp+hwgeyPgIXX0SrCSOcjeJLsMsCmMac9ewvb+AN8y4k+N7m5lD/dMZupsaateKTFwA==",
+      "version": "9.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-9.0.17.tgz",
+      "integrity": "sha512-m24F1COquwOm7PBl5wRbkT9P9DviCXe0D7S7nQsolfbhdCWuvMkfXeoWmgjtdhy7sDlOyIgBrAdnB6MfsWKqIg==",
       "dependencies": {
-        "@expo/config-types": "^52.0.4",
-        "@expo/json-file": "~9.0.1",
-        "@expo/plist": "^0.2.1",
+        "@expo/config-types": "^52.0.5",
+        "@expo/json-file": "~9.0.2",
+        "@expo/plist": "^0.2.2",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
@@ -2358,9 +2359,9 @@
       }
     },
     "node_modules/@expo/config-types": {
-      "version": "52.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-52.0.4.tgz",
-      "integrity": "sha512-oMGrb2o3niVCIfjnIHFrOoiDA9jGb0lc3G4RI1UiO//KjULBaQr3QTBoKDzZQwMqDV1AgYgSr9mgEcnX3LqhIg=="
+      "version": "52.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-52.0.5.tgz",
+      "integrity": "sha512-AMDeuDLHXXqd8W+0zSjIt7f37vUd/BP8p43k68NHpyAvQO+z8mbQZm3cNQVAMySeayK2XoPigAFB1JF2NFajaA=="
     },
     "node_modules/@expo/config/node_modules/@babel/code-frame": {
       "version": "7.10.4",
@@ -2539,15 +2540,15 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "0.19.11",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.19.11.tgz",
-      "integrity": "sha512-XaobHTcsoHQdKEH7PI/DIpr2QiugkQmPYolbfzkpSJMplNWfSh+cTRjrm4//mS2Sb78qohtu0u2CGJnFqFUGag==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.19.12.tgz",
+      "integrity": "sha512-fhT3x1ikQWHpZgw7VrEghBdscFPz1laRYa8WcVRB18nTTqorF6S8qPYslkJu1faEziHZS7c2uyDzTYnrg/CKbg==",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
         "@babel/parser": "^7.20.0",
         "@babel/types": "^7.20.0",
-        "@expo/config": "~10.0.10",
+        "@expo/config": "~10.0.11",
         "@expo/env": "~0.4.2",
         "@expo/json-file": "~9.0.2",
         "@expo/spawn-async": "^1.7.2",
@@ -2644,16 +2645,16 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "8.0.28",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-8.0.28.tgz",
-      "integrity": "sha512-SDDgCKKS1wFNNm3de2vBP8Q5bnxcabuPDE9Mnk9p7Gb4qBavhwMbAtrLcAyZB+WRb4QM+yan3z3K95vvCfI/+A==",
+      "version": "8.0.30",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-8.0.30.tgz",
+      "integrity": "sha512-xNHWGh0xLZjxBXwVbDW+TPeexuQ95FZX2ZRrzJkALxhQiwYQswQSFE7CVUFMC2USIKVklCcgfEvtqnguTBQVxQ==",
       "dependencies": {
-        "@expo/config": "~10.0.10",
-        "@expo/config-plugins": "~9.0.15",
-        "@expo/config-types": "^52.0.4",
+        "@expo/config": "~10.0.11",
+        "@expo/config-plugins": "~9.0.17",
+        "@expo/config-types": "^52.0.5",
         "@expo/image-utils": "^0.6.5",
         "@expo/json-file": "^9.0.2",
-        "@react-native/normalize-colors": "0.76.7",
+        "@react-native/normalize-colors": "0.76.8",
         "debug": "^4.3.1",
         "fs-extra": "^9.0.0",
         "resolve-from": "^5.0.0",
@@ -2747,9 +2748,9 @@
       }
     },
     "node_modules/@expo/ws-tunnel": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.5.tgz",
-      "integrity": "sha512-Ta9KzslHAIbw2ZoyZ7Ud7/QImucy+K4YvOqo9AhGfUfH76hQzaffQreOySzYusDfW8Y+EXh0ZNWE68dfCumFFw=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.6.tgz",
+      "integrity": "sha512-nDRbLmSrJar7abvUjp3smDwH8HcbZcoOEa5jVPUv9/9CajgmWw20JNRwTuBRzWIWIkEJDkz20GoNA+tSwUqk0Q=="
     },
     "node_modules/@expo/xcpretty": {
       "version": "4.3.2",
@@ -3184,28 +3185,28 @@
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.76.7.tgz",
-      "integrity": "sha512-o79whsqL5fbPTUQO9w1FptRd4cw1TaeOrXtQSLQeDrMVAenw/wmsjyPK10VKtvqxa1KNMtWEyfgxcM8CVZVFmg==",
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.76.8.tgz",
+      "integrity": "sha512-vQQi3kabQpj21Iohy2ou3/laCRE5hlW4r122ZivqCIN/UMwr5vT2/fTgPOBQoJ5X3YhZBe58BmifIstZutm0Ew==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.7.tgz",
-      "integrity": "sha512-+8H4DXJREM4l/pwLF/wSVMRzVhzhGDix5jLezNrMD9J1U1AMfV2aSkWA1XuqR7pjPs/Vqf6TaPL7vJMZ4LU05Q==",
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.8.tgz",
+      "integrity": "sha512-84RUEhDZS+q7vPtxKi0iMZLd5/W0VN7NOyqX5f+burV3xMYpUhpF5TDJ2Ysol7dJrvEZHm6ISAriO85++V8YDw==",
       "dependencies": {
-        "@react-native/codegen": "0.76.7"
+        "@react-native/codegen": "0.76.8"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.76.7.tgz",
-      "integrity": "sha512-/c5DYZ6y8tyg+g8tgXKndDT7mWnGmkZ9F+T3qNDfoE3Qh7ucrNeC2XWvU9h5pk8eRtj9l4SzF4aO1phzwoibyg==",
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.76.8.tgz",
+      "integrity": "sha512-xrP+r3orRzzxtC2TrfGIP6IYi1f4AiWlnSiWf4zxEdMFzKrYdmxhD0FPtAZb77B0DqFIW5AcBFlm4grfL/VgfA==",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "@babel/plugin-proposal-export-default-from": "^7.24.7",
@@ -3248,7 +3249,7 @@
         "@babel/plugin-transform-typescript": "^7.25.2",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
         "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.76.7",
+        "@react-native/babel-plugin-codegen": "0.76.8",
         "babel-plugin-syntax-hermes-parser": "^0.25.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
@@ -3261,9 +3262,9 @@
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.76.7.tgz",
-      "integrity": "sha512-FAn585Ll65YvkSrKDyAcsdjHhhAGiMlSTUpHh0x7J5ntudUns+voYms0xMP+pEPt0XuLdjhD7zLIIlAWP407+g==",
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.76.8.tgz",
+      "integrity": "sha512-qvKhcYBkRHJFkeWrYm66kEomQOTVXWiHBkZ8VF9oC/71OJkLszpTpVOuPIyyib6fqhjy9l7mHYGYenSpfYI5Ww==",
       "dependencies": {
         "@babel/parser": "^7.25.3",
         "glob": "^7.1.1",
@@ -3302,12 +3303,12 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.76.7.tgz",
-      "integrity": "sha512-lrcsY2WPLCEWU1pjdNV9+Ccj8vCEwCCURZiPa5aqi7lKB4C++1hPrxA8/CWWnTNcQp76DsBKGYqTFj7Ud4aupw==",
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.76.8.tgz",
+      "integrity": "sha512-3rs6YehAVEootGpzchmj1ln2BCSTnIDTKqAYykUggEwpplg+CNTiBrvRrnjmlLXk3nOlIE8KOw4zRCd3PpI+bg==",
       "dependencies": {
-        "@react-native/dev-middleware": "0.76.7",
-        "@react-native/metro-babel-transformer": "0.76.7",
+        "@react-native/dev-middleware": "0.76.8",
+        "@react-native/metro-babel-transformer": "0.76.8",
         "chalk": "^4.0.0",
         "execa": "^5.1.1",
         "invariant": "^2.2.4",
@@ -3322,10 +3323,10 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@react-native-community/cli-server-api": "*"
+        "@react-native-community/cli": "*"
       },
       "peerDependenciesMeta": {
-        "@react-native-community/cli-server-api": {
+        "@react-native-community/cli": {
           "optional": true
         }
       }
@@ -3424,20 +3425,20 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.76.7.tgz",
-      "integrity": "sha512-89ZtZXt7ZxE94i7T94qzZMhp4Gfcpr/QVpGqEaejAxZD+gvDCH21cYSF+/Rz2ttBazm0rk5MZ0mFqb0Iqp1jmw==",
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.76.8.tgz",
+      "integrity": "sha512-kSukBw2C++5ENLUCAp/1uEeiFgiHi/MBa71Wgym3UD5qwu2vOSPOTSKRX7q2Jb676MUzTcrIaJBZ/r2qk25u7Q==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.76.7.tgz",
-      "integrity": "sha512-Jsw8g9DyLPnR9yHEGuT09yHZ7M88/GL9CtU9WmyChlBwdXSeE3AmRqLegsV3XcgULQ1fqdemokaOZ/MwLYkjdA==",
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.76.8.tgz",
+      "integrity": "sha512-KYx7hFME2uYQRCDCqb19ghw51TAdh48PZ5EMpoU2kPA1SKKO9c1bUbpsKRhVZ0bv1QqEX6fjox3c4/WYRozHQA==",
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.76.7",
+        "@react-native/debugger-frontend": "0.76.8",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
@@ -3475,28 +3476,28 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.76.7.tgz",
-      "integrity": "sha512-gQI6RcrJbigU8xk7F960C5xQIgvbBj20TUvGecD+N2PHfbLpqR+92cj7hz3UcbrCONmTP40WHnbMMJ8P+kLsrA==",
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.76.8.tgz",
+      "integrity": "sha512-rgocQRydHS8IkcyUs1VFhz+Q0OjL3QYI5/A7pMLRz6nEW8GAmoFnXqwujtPHivVrXbuCLIzGBKnsl2hsZsOopg==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.76.7.tgz",
-      "integrity": "sha512-+iEikj6c6Zvrg1c3cYMeiPB+5nS8EaIC3jCtP6Muk3qc7c386IymEPM2xycIlfg04DPZvO3D4P2/vaO9/TCnUg==",
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.76.8.tgz",
+      "integrity": "sha512-bZzPjpDQaWU+F//N/WZJfaglYgYga4oXl9rzXyKOJP7KcebkOKJbAsG1mo7RCOVIbHYQCKUvQXIpV3IQOWNOEg==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/metro-babel-transformer": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.76.7.tgz",
-      "integrity": "sha512-jDS1wR7q46xY5ah+jF714Mvss9l7+lmwW/tplahZgLKozkYDC8Td5o9TOCgKlv18acw9H1V7zv8ivuRSj8ICPg==",
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.76.8.tgz",
+      "integrity": "sha512-tEjNJo3Wwiig1OmI7H3cLOrAkAxT9lBqs1k+oanRm64o0Cay2ACH0PdXrk45sxENU3iTfxXeQ7mmY1u2XVYDpw==",
       "dependencies": {
         "@babel/core": "^7.25.2",
-        "@react-native/babel-preset": "0.76.7",
+        "@react-native/babel-preset": "0.76.8",
         "hermes-parser": "0.23.1",
         "nullthrows": "^1.1.1"
       },
@@ -3508,14 +3509,14 @@
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.76.7.tgz",
-      "integrity": "sha512-ST1xxBuYVIXPdD81dR6+tzIgso7m3pa9+6rOBXTh5Xm7KEEFik7tnQX+GydXYMp3wr1gagJjragdXkPnxK6WNg=="
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.76.8.tgz",
+      "integrity": "sha512-FRjRvs7RgsXjkbGSOjYSxhX5V70c0IzA/jy3HXeYpATMwD9fOR1DbveLW497QGsVdCa0vThbJUtR8rIzAfpHQA=="
     },
     "node_modules/@react-native/virtualized-lists": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.76.7.tgz",
-      "integrity": "sha512-pRUf1jUO8H9Ft04CaWv76t34QI9wY0sydoYlIwEtqXjjMJgmgDoOCAWBjArgn2mk8/rK+u/uicI67ZCYCp1pJw==",
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.76.8.tgz",
+      "integrity": "sha512-OsB+LoEFH80wL+qhQrNpJR3O3oNDmyZf0go7/MQiayZbT8IkD8aPdHmK4QIVoIwAbFWXw7RkcFdubhSWwi0wAQ==",
       "dependencies": {
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1"
@@ -4030,20 +4031,20 @@
       "dev": true
     },
     "node_modules/@urql/core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-5.1.0.tgz",
-      "integrity": "sha512-yC3sw8yqjbX45GbXxfiBY8GLYCiyW/hLBbQF9l3TJrv4ro00Y0ChkKaD9I2KntRxAVm9IYBqh0awX8fwWAe/Yw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-5.1.1.tgz",
+      "integrity": "sha512-aGh024z5v2oINGD/In6rAtVKTm4VmQ2TxKQBAtk2ZSME5dunZFcjltw4p5ENQg+5CBhZ3FHMzl0Oa+rwqiWqlg==",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5",
         "wonka": "^6.3.2"
       }
     },
     "node_modules/@urql/exchange-retry": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.3.0.tgz",
-      "integrity": "sha512-FLt+d81gP4oiHah4hWFDApimc+/xABWMU1AMYsZ1PVB0L0YPtrMCjbOp9WMM7hBzy4gbTDrG24sio0dCfSh/HQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.3.1.tgz",
+      "integrity": "sha512-EEmtFu8JTuwsInqMakhLq+U3qN8ZMd5V3pX44q0EqD2imqTDsa8ikZqJ1schVrN8HljOdN+C08cwZ1/r5uIgLw==",
       "dependencies": {
-        "@urql/core": "^5.0.0",
+        "@urql/core": "^5.1.1",
         "wonka": "^6.3.2"
       },
       "peerDependencies": {
@@ -4619,9 +4620,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-12.0.8.tgz",
-      "integrity": "sha512-bojAddWZJusLs3NVdF+jN3WweTYVEZXBKIeO0sOhqOg7UPh5w1bnMkx7SDua0FgQMGBxb13qM31Y46yeZnmXjw==",
+      "version": "12.0.10",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-12.0.10.tgz",
+      "integrity": "sha512-6QE52Bxsp5XRE8t0taKRFTFsmTG0ThQE+PTgCgLY9s8v2Aeh8R+E+riXhSHX6hP+diDmBFBdvLCUTq7kroJb1Q==",
       "dependencies": {
         "@babel/plugin-proposal-decorators": "^7.12.9",
         "@babel/plugin-transform-export-namespace-from": "^7.22.11",
@@ -4629,7 +4630,7 @@
         "@babel/plugin-transform-parameters": "^7.22.15",
         "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.76.7",
+        "@react-native/babel-preset": "0.76.8",
         "babel-plugin-react-native-web": "~0.19.13",
         "react-refresh": "^0.14.2"
       },
@@ -6626,31 +6627,33 @@
       }
     },
     "node_modules/expo": {
-      "version": "52.0.36",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-52.0.36.tgz",
-      "integrity": "sha512-3QYoxz1+dW3IhBDuPUcw66K6GMUfwlZgXP42ypBT5d54X5AGPSo4Mk5RZxt6Buu+5K6F3qenml9B5snH/OvKIg==",
+      "version": "52.0.42",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-52.0.42.tgz",
+      "integrity": "sha512-t+PRYIzzPFAlF99OVJOjZwM1glLhN85XGD6vmeg6uwpADDILl9yw4dfy0DXL4hot5GJkAGaZ+uOHUljV4kC2Bg==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.22.17",
-        "@expo/config": "~10.0.10",
-        "@expo/config-plugins": "~9.0.15",
+        "@expo/cli": "0.22.23",
+        "@expo/config": "~10.0.11",
+        "@expo/config-plugins": "~9.0.17",
         "@expo/fingerprint": "0.11.11",
-        "@expo/metro-config": "0.19.11",
+        "@expo/metro-config": "0.19.12",
         "@expo/vector-icons": "^14.0.0",
-        "babel-preset-expo": "~12.0.8",
-        "expo-asset": "~11.0.4",
-        "expo-constants": "~17.0.7",
-        "expo-file-system": "~18.0.11",
+        "babel-preset-expo": "~12.0.10",
+        "expo-asset": "~11.0.5",
+        "expo-constants": "~17.0.8",
+        "expo-file-system": "~18.0.12",
         "expo-font": "~13.0.4",
         "expo-keep-awake": "~14.0.3",
         "expo-modules-autolinking": "2.0.8",
-        "expo-modules-core": "2.2.2",
+        "expo-modules-core": "2.2.3",
         "fbemitter": "^3.0.0",
         "web-streams-polyfill": "^3.3.2",
         "whatwg-url-without-unicode": "8.0.0-3"
       },
       "bin": {
-        "expo": "bin/cli"
+        "expo": "bin/cli",
+        "expo-modules-autolinking": "bin/autolinking",
+        "fingerprint": "bin/fingerprint"
       },
       "peerDependencies": {
         "@expo/dom-webview": "*",
@@ -6672,12 +6675,12 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.0.4.tgz",
-      "integrity": "sha512-CdIywU0HrR3wsW5c3n0cT3jW9hccZdnqGsRqY+EY/RWzJbDXtDfAQVEiFHO3mDK7oveUwrP2jK/6ZRNek41/sg==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.0.5.tgz",
+      "integrity": "sha512-TL60LmMBGVzs3NQcO8ylWqBumMh4sx0lmeJsn7+9C88fylGDhyyVnKZ1PyTXo9CVDBkndutZx2JUEQWM9BaiXw==",
       "dependencies": {
         "@expo/image-utils": "^0.6.5",
-        "expo-constants": "~17.0.7",
+        "expo-constants": "~17.0.8",
         "invariant": "^2.2.4",
         "md5-file": "^3.2.3"
       },
@@ -6688,11 +6691,11 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.0.7.tgz",
-      "integrity": "sha512-sp5NUiV17I3JblVPIBDgoxgt7JIZS30vcyydCYHxsEoo+aKaeRYXxGYilCvb9lgI6BBwSL24sQ6ZjWsCWoF1VA==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.0.8.tgz",
+      "integrity": "sha512-XfWRyQAf1yUNgWZ1TnE8pFBMqGmFP5Gb+SFSgszxDdOoheB/NI5D4p7q86kI2fvGyfTrxAe+D+74nZkfsGvUlg==",
       "dependencies": {
-        "@expo/config": "~10.0.10",
+        "@expo/config": "~10.0.11",
         "@expo/env": "~0.4.2"
       },
       "peerDependencies": {
@@ -6701,9 +6704,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "18.0.11",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.0.11.tgz",
-      "integrity": "sha512-yDwYfEzWgPXsBZHJW2RJ8Q66ceiFN9Wa5D20pp3fjXVkzPBDwxnYwiPWk4pVmCa5g4X5KYMoMne1pUrsL4OEpg==",
+      "version": "18.0.12",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.0.12.tgz",
+      "integrity": "sha512-HAkrd/mb8r+G3lJ9MzmGeuW2B+BxQR1joKfeCyY4deLl1zoZ48FrAWjgZjHK9aHUVhJ0ehzInu/NQtikKytaeg==",
       "dependencies": {
         "web-streams-polyfill": "^3.3.2"
       },
@@ -6785,9 +6788,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-2.2.2.tgz",
-      "integrity": "sha512-SgjK86UD89gKAscRK3bdpn6Ojfs/KU4GujtuFx1wm4JaBjmXH4aakWkItkPlAV2pjIiHJHWQbENL9xjbw/Qr/g==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-2.2.3.tgz",
+      "integrity": "sha512-01QqZzpP/wWlxnNly4G06MsOBUTbMDj02DQigZoXfDh80vd/rk3/uVXqnZgOdLSggTs6DnvOgAUy0H2q30XdUg==",
       "dependencies": {
         "invariant": "^2.2.4"
       }
@@ -7034,11 +7037,11 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -9445,9 +9448,9 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.81.1.tgz",
-      "integrity": "sha512-fqRu4fg8ONW7VfqWFMGgKAcOuMzyoQah2azv9Y3VyFXAmG+AoTU6YIFWqAADESCGVWuWEIvxTJhMf3jxU6jwjA==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.81.4.tgz",
+      "integrity": "sha512-78f0aBNPuwXW7GFnSc+Y0vZhbuQorXxdgqQfvSRqcSizqwg9cwF27I05h47tL8AzQcizS1JZncvq4xf5u/Qykw==",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
         "@babel/core": "^7.25.2",
@@ -9467,21 +9470,21 @@
         "hermes-parser": "0.25.1",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
-        "jest-worker": "^29.6.3",
+        "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.81.1",
-        "metro-cache": "0.81.1",
-        "metro-cache-key": "0.81.1",
-        "metro-config": "0.81.1",
-        "metro-core": "0.81.1",
-        "metro-file-map": "0.81.1",
-        "metro-resolver": "0.81.1",
-        "metro-runtime": "0.81.1",
-        "metro-source-map": "0.81.1",
-        "metro-symbolicate": "0.81.1",
-        "metro-transform-plugins": "0.81.1",
-        "metro-transform-worker": "0.81.1",
+        "metro-babel-transformer": "0.81.4",
+        "metro-cache": "0.81.4",
+        "metro-cache-key": "0.81.4",
+        "metro-config": "0.81.4",
+        "metro-core": "0.81.4",
+        "metro-file-map": "0.81.4",
+        "metro-resolver": "0.81.4",
+        "metro-runtime": "0.81.4",
+        "metro-source-map": "0.81.4",
+        "metro-symbolicate": "0.81.4",
+        "metro-transform-plugins": "0.81.4",
+        "metro-transform-worker": "0.81.4",
         "mime-types": "^2.1.27",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -9498,9 +9501,9 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.81.1.tgz",
-      "integrity": "sha512-JECKDrQaUnDmj0x/Q/c8c5YwsatVx38Lu+BfCwX9fR8bWipAzkvJocBpq5rOAJRDXRgDcPv2VO4Q4nFYrpYNQg==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.81.4.tgz",
+      "integrity": "sha512-WW0yswWrW+eTVK9sYD+b1HwWOiUlZlUoomiw9TIOk0C+dh2V90Wttn/8g62kYi0Y4i+cJfISerB2LbV4nuRGTA==",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
@@ -9525,22 +9528,22 @@
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.81.1.tgz",
-      "integrity": "sha512-Uqcmn6sZ+Y0VJHM88VrG5xCvSeU7RnuvmjPmSOpEcyJJBe02QkfHL05MX2ZyGDTyZdbKCzaX0IijrTe4hN3F0Q==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.81.4.tgz",
+      "integrity": "sha512-sxCPH3gowDxazSaZZrwdNPEpnxR8UeXDnvPjBF9+5btDBNN2DpWvDAXPvrohkYkFImhc0LajS2V7eOXvu9PnvQ==",
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
-        "metro-core": "0.81.1"
+        "metro-core": "0.81.4"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.81.1.tgz",
-      "integrity": "sha512-5fDaHR1yTvpaQuwMAeEoZGsVyvjrkw9IFAS7WixSPvaNY5YfleqoJICPc6hbXFJjvwCCpwmIYFkjqzR/qJ6yqA==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.81.4.tgz",
+      "integrity": "sha512-3SaWQybvf1ivasjBegIxzVKLJzOpcz+KsnGwXFOYADQq0VN4cnM7tT+u2jkOhk6yJiiO1WIjl68hqyMOQJRRLg==",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
@@ -9549,47 +9552,47 @@
       }
     },
     "node_modules/metro-config": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.81.1.tgz",
-      "integrity": "sha512-VAAJmxsKIZ+Fz5/z1LVgxa32gE6+2TvrDSSx45g85WoX4EtLmdBGP3DSlpQW3DqFUfNHJCGwMLGXpJnxifd08g==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.81.4.tgz",
+      "integrity": "sha512-QnhMy3bRiuimCTy7oi5Ug60javrSa3lPh0gpMAspQZHY9h6y86jwHtZPLtlj8hdWQESIlrbeL8inMSF6qI/i9Q==",
       "dependencies": {
         "connect": "^3.6.5",
         "cosmiconfig": "^5.0.5",
         "flow-enums-runtime": "^0.0.6",
-        "jest-validate": "^29.6.3",
-        "metro": "0.81.1",
-        "metro-cache": "0.81.1",
-        "metro-core": "0.81.1",
-        "metro-runtime": "0.81.1"
+        "jest-validate": "^29.7.0",
+        "metro": "0.81.4",
+        "metro-cache": "0.81.4",
+        "metro-core": "0.81.4",
+        "metro-runtime": "0.81.4"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/metro-core": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.81.1.tgz",
-      "integrity": "sha512-4d2/+02IYqOwJs4dmM0dC8hIZqTzgnx2nzN4GTCaXb3Dhtmi/SJ3v6744zZRnithhN4lxf8TTJSHnQV75M7SSA==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.81.4.tgz",
+      "integrity": "sha512-GdL4IgmgJhrMA/rTy2lRqXKeXfC77Rg+uvhUEkbhyfj/oz7PrdSgvIFzziapjdHwk1XYq0KyFh/CcVm8ZawG6A==",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.81.1"
+        "metro-resolver": "0.81.4"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.81.1.tgz",
-      "integrity": "sha512-aY72H2ujmRfFxcsbyh83JgqFF+uQ4HFN1VhV2FmcfQG4s1bGKf2Vbkk+vtZ1+EswcBwDZFbkpvAjN49oqwGzAA==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.81.4.tgz",
+      "integrity": "sha512-qUIBzkiqOi3qEuscu4cJ83OYQ4hVzjON19FAySWqYys9GKCmxlKa7LkmwqdpBso6lQl+JXZ7nCacX90w5wQvPA==",
       "dependencies": {
         "debug": "^2.2.0",
         "fb-watchman": "^2.0.0",
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
         "invariant": "^2.2.4",
-        "jest-worker": "^29.6.3",
+        "jest-worker": "^29.7.0",
         "micromatch": "^4.0.4",
         "nullthrows": "^1.1.1",
         "walker": "^1.0.7"
@@ -9612,9 +9615,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.81.1.tgz",
-      "integrity": "sha512-p/Qz3NNh1nebSqMlxlUALAnESo6heQrnvgHtAuxufRPtKvghnVDq9hGGex8H7z7YYLsqe42PWdt4JxTA3mgkvg==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.81.4.tgz",
+      "integrity": "sha512-oVvq/AGvqmbhuijJDZZ9npeWzaVyeBwQKtdlnjcQ9fH7nR15RiBr5y2zTdgTEdynqOIb1Kc16l8CQIUSzOWVFA==",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "terser": "^5.15.0"
@@ -9624,9 +9627,9 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.81.1.tgz",
-      "integrity": "sha512-E61t6fxRoYRkl6Zo3iUfCKW4DYfum/bLjcejXBMt1y3I7LFkK84TCR/Rs9OAwsMCY/7GOPB4+CREYZOtCC7CNA==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.81.4.tgz",
+      "integrity": "sha512-Ng7G2mXjSExMeRzj6GC19G6IJ0mfIbOLgjArsMWJgtt9ViZiluCwgWsMW9juBC5NSwjJxUMK2x6pC5NIMFLiHA==",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
@@ -9635,9 +9638,9 @@
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.81.1.tgz",
-      "integrity": "sha512-pqu5j5d01rjF85V/K8SDDJ0NR3dRp6bE3z5bKVVb5O2Rx0nbR9KreUxYALQCRCcQHaYySqCg5fYbGKBHC295YQ==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.81.4.tgz",
+      "integrity": "sha512-fBoRgqkF69CwyPtBNxlDi5ha26Zc8f85n2THXYoh13Jn/Bkg8KIDCdKPp/A1BbSeNnkH/++H2EIIfnmaff4uRg==",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "flow-enums-runtime": "^0.0.6"
@@ -9647,18 +9650,18 @@
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.81.1.tgz",
-      "integrity": "sha512-1i8ROpNNiga43F0ZixAXoFE/SS3RqcRDCCslpynb+ytym0VI7pkTH1woAN2HI9pczYtPrp3Nq0AjRpsuY35ieA==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.81.4.tgz",
+      "integrity": "sha512-IOwVQ7mLqoqvsL70RZtl1EyE3f9jp43kVsAsb/B/zoWmu0/k4mwEhGLTxmjdXRkLJqPqPrh7WmFChAEf9trW4Q==",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
         "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3",
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.81.1",
+        "metro-symbolicate": "0.81.4",
         "nullthrows": "^1.1.1",
-        "ob1": "0.81.1",
+        "ob1": "0.81.4",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -9667,13 +9670,13 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.81.1.tgz",
-      "integrity": "sha512-Lgk0qjEigtFtsM7C0miXITbcV47E1ZYIfB+m/hCraihiwRWkNUQEPCWvqZmwXKSwVE5mXA0EzQtghAvQSjZDxw==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.81.4.tgz",
+      "integrity": "sha512-rWxTmYVN6/BOSaMDUHT8HgCuRf6acd0AjHkenYlHpmgxg7dqdnAG1hLq999q2XpW5rX+cMamZD5W5Ez2LqGaag==",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.81.1",
+        "metro-source-map": "0.81.4",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -9686,9 +9689,9 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.81.1.tgz",
-      "integrity": "sha512-7L1lI44/CyjIoBaORhY9fVkoNe8hrzgxjSCQ/lQlcfrV31cZb7u0RGOQrKmUX7Bw4FpejrB70ArQ7Mse9mk7+Q==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.81.4.tgz",
+      "integrity": "sha512-nlP069nDXm4v28vbll4QLApAlvVtlB66rP6h+ml8Q/CCQCPBXu2JLaoxUmkIOJQjLhMRUcgTyQHq+TXWJhydOQ==",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "@babel/generator": "^7.25.0",
@@ -9702,22 +9705,22 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.81.1.tgz",
-      "integrity": "sha512-M+2hVT3rEy5K7PBmGDgQNq3Zx53TjScOcO/CieyLnCRFtBGWZiSJ2+bLAXXOKyKa/y3bI3i0owxtyxuPGDwbZg==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.81.4.tgz",
+      "integrity": "sha512-lKAeRZ8EUMtx2cA/Y4KvICr9bIr5SE03iK3lm+l9wyn2lkjLUuPjYVep159inLeDqC6AtSubsA8MZLziP7c03g==",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "@babel/generator": "^7.25.0",
         "@babel/parser": "^7.25.3",
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.81.1",
-        "metro-babel-transformer": "0.81.1",
-        "metro-cache": "0.81.1",
-        "metro-cache-key": "0.81.1",
-        "metro-minify-terser": "0.81.1",
-        "metro-source-map": "0.81.1",
-        "metro-transform-plugins": "0.81.1",
+        "metro": "0.81.4",
+        "metro-babel-transformer": "0.81.4",
+        "metro-cache": "0.81.4",
+        "metro-cache-key": "0.81.4",
+        "metro-minify-terser": "0.81.4",
+        "metro-source-map": "0.81.4",
+        "metro-transform-plugins": "0.81.4",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -9810,9 +9813,9 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
-      "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -10154,9 +10157,9 @@
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="
     },
     "node_modules/ob1": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.81.1.tgz",
-      "integrity": "sha512-1PEbvI+AFvOcgdNcO79FtDI1TUO8S3lhiKOyAiyWQF3sFDDKS+aw2/BZvGlArFnSmqckwOOB9chQuIX0/OahoQ==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.81.4.tgz",
+      "integrity": "sha512-EZLYM8hfPraC2SYOR5EWLFAPV5e6g+p83m2Jth9bzCpFxP1NDQJYXdmXRB2bfbaWQSmm6NkIQlbzk7uU5lLfgg==",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
@@ -11174,18 +11177,18 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/react-native": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.76.7.tgz",
-      "integrity": "sha512-GPJcQeO3qUi1MvuhsC2DC6tH8gJQ4uc4JWPORrdeuCGFWE3QLsN8/hiChTEvJREHLfQSV61YPI8gIOtAQ8c37g==",
+      "version": "0.76.8",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.76.8.tgz",
+      "integrity": "sha512-sVoAd/cDBdVoLjNz8Lp5DAg4l6Iag0l5AiChN2J/NGhM//PW6+MIW50TI8G1iZz4rquAgWtcCHwEp5P5FvMyDA==",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.6.3",
-        "@react-native/assets-registry": "0.76.7",
-        "@react-native/codegen": "0.76.7",
-        "@react-native/community-cli-plugin": "0.76.7",
-        "@react-native/gradle-plugin": "0.76.7",
-        "@react-native/js-polyfills": "0.76.7",
-        "@react-native/normalize-colors": "0.76.7",
-        "@react-native/virtualized-lists": "0.76.7",
+        "@react-native/assets-registry": "0.76.8",
+        "@react-native/codegen": "0.76.8",
+        "@react-native/community-cli-plugin": "0.76.8",
+        "@react-native/gradle-plugin": "0.76.8",
+        "@react-native/js-polyfills": "0.76.8",
+        "@react-native/normalize-colors": "0.76.8",
+        "@react-native/virtualized-lists": "0.76.8",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -11233,10 +11236,19 @@
         }
       }
     },
+    "node_modules/react-native-safe-area-context": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.12.0.tgz",
+      "integrity": "sha512-ukk5PxcF4p3yu6qMZcmeiZgowhb5AsKRnil54YFUUAXVIS7PJcMHGGC+q44fCiBg44/1AJk5njGMez1m9H0BVQ==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-webview": {
-      "version": "13.13.2",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.13.2.tgz",
-      "integrity": "sha512-zACPDTF0WnaEnKZ9mA/r/UpcOpV2gQM06AAIrOOexnO8UJvXL8Pjso0b/wTqKFxUZZnmjKuwd8gHVUosVOdVrw==",
+      "version": "13.12.5",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.12.5.tgz",
+      "integrity": "sha512-INOKPom4dFyzkbxbkuQNfeRG9/iYnyRDzrDkJeyvSWgJAW2IDdJkWFJBS2v0RxIL4gqLgHkiIZDOfiLaNnw83Q==",
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
@@ -13127,9 +13139,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
       "engines": {
         "node": ">=18.17"
       }
@@ -13479,9 +13491,9 @@
       }
     },
     "node_modules/wonka": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.4.tgz",
-      "integrity": "sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg=="
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.5.tgz",
+      "integrity": "sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw=="
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -13604,9 +13616,9 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frolog_app_practice",
   "version": "1.0.0",
-  "main": "index.ts",
+  "main": "./src/index.ts",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   "dependencies": {
     "@react-navigation/native": "^7.0.14",
     "cocoapods": "^0.0.0",
-    "expo": "~52.0.36",
+    "expo": "^52.0.42",
     "expo-status-bar": "~2.0.1",
     "react": "18.3.1",
-    "react-native": "0.76.7",
-    "react-native-webview": "^13.13.2"
+    "react-native": "^0.76.8",
+    "react-native-safe-area-context": "^4.12.0",
+    "react-native-webview": "^13.12.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,28 @@
+import { StatusBar } from 'expo-status-bar';
+import { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import WebView from 'react-native-webview';
 
 export default function App() {
+  const [statusBarStyle, setStatusBarStyle] = useState<
+    'light' | 'dark' | 'auto'
+  >('light');
+
+  const handleChangeNavigation = (url: string) => {
+    if (url.includes('search') && !url.includes('search-home'))
+      return setStatusBarStyle('dark');
+    setStatusBarStyle('light');
+  };
+
   return (
     <View style={styles.container}>
-      <WebView source={{ uri: 'https://www.frolog.kr' }} />
+      <StatusBar style={statusBarStyle} />
+      <WebView
+        source={{ uri: 'https://www.frolog.kr' }}
+        onNavigationStateChange={(navState) =>
+          handleChangeNavigation(navState.url)
+        }
+      />
     </View>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,10 @@
-import { StatusBar } from 'expo-status-bar';
-import { useState } from 'react';
-import { StyleSheet, View } from 'react-native';
-import WebView from 'react-native-webview';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import MainWebView from './components/MainWebView';
 
 export default function App() {
-  const [statusBarStyle, setStatusBarStyle] = useState<
-    'light' | 'dark' | 'auto'
-  >('light');
-
-  const handleChangeNavigation = (url: string) => {
-    if (url.includes('search') && !url.includes('search-home'))
-      return setStatusBarStyle('dark');
-    setStatusBarStyle('light');
-  };
-
   return (
-    <View style={styles.container}>
-      <StatusBar style={statusBarStyle} />
-      <WebView
-        source={{ uri: 'https://www.frolog.kr' }}
-        onNavigationStateChange={(navState) =>
-          handleChangeNavigation(navState.url)
-        }
-      />
-    </View>
+    <SafeAreaProvider>
+      <MainWebView />
+    </SafeAreaProvider>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-});

--- a/src/components/MainWebView.tsx
+++ b/src/components/MainWebView.tsx
@@ -17,6 +17,8 @@ function MainWebView() {
     const { nativeEvent } = event;
     const { type, data } = JSON.parse(nativeEvent.data);
 
+    console.log(type, data);
+
     if (type === 'THEME' && THEME_COLOR[data]) setThemeState(THEME_COLOR[data]);
   };
 
@@ -41,9 +43,10 @@ function MainWebView() {
         ]}
       >
         <WebView
-          source={{ uri: 'https://frolog.kr' }}
+          source={{ uri: 'http://localhost:3000' }}
           onMessage={(event) => handleMessage(event)}
           onShouldStartLoadWithRequest={(req) => handleExternalPage(req)}
+          allowsBackForwardNavigationGestures
         />
       </View>
     </>

--- a/src/components/MainWebView.tsx
+++ b/src/components/MainWebView.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { StatusBar, StatusBarStyle } from 'expo-status-bar';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import WebView, { WebViewMessageEvent } from 'react-native-webview';
+import { THEME_COLOR } from '../constants/theme';
+
+function MainWebView() {
+  const [themeState, setThemeState] = useState({
+    color: 'light' as StatusBarStyle,
+    bgColor: '#fff',
+  });
+  const insets = useSafeAreaInsets();
+
+  const handleMessage = (event: WebViewMessageEvent) => {
+    const { nativeEvent } = event;
+    const { type, data } = JSON.parse(nativeEvent.data);
+
+    if (type === 'THEME' && THEME_COLOR[data]) setThemeState(THEME_COLOR[data]);
+  };
+  return (
+    <>
+      <StatusBar style={themeState.color} />
+      <View
+        style={[
+          styles.container,
+          {
+            paddingTop: insets.top,
+            backgroundColor: themeState.bgColor,
+          },
+        ]}
+      >
+        <WebView
+          source={{ uri: 'https://frolog.kr' }}
+          onMessage={(event) => handleMessage(event)}
+        />
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});
+
+export default MainWebView;

--- a/src/components/MainWebView.tsx
+++ b/src/components/MainWebView.tsx
@@ -17,8 +17,6 @@ function MainWebView() {
     const { nativeEvent } = event;
     const { type, data } = JSON.parse(nativeEvent.data);
 
-    console.log(type, data);
-
     if (type === 'THEME' && THEME_COLOR[data]) setThemeState(THEME_COLOR[data]);
   };
 

--- a/src/components/MainWebView.tsx
+++ b/src/components/MainWebView.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { StatusBar, StatusBarStyle } from 'expo-status-bar';
-import { StyleSheet, View } from 'react-native';
+import { Linking, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import WebView, { WebViewMessageEvent } from 'react-native-webview';
+import { ShouldStartLoadRequest } from 'react-native-webview/lib/WebViewTypes';
 import { THEME_COLOR } from '../constants/theme';
 
 function MainWebView() {
@@ -18,6 +19,15 @@ function MainWebView() {
 
     if (type === 'THEME' && THEME_COLOR[data]) setThemeState(THEME_COLOR[data]);
   };
+
+  const handleExternalPage = (req: ShouldStartLoadRequest) => {
+    if (req.url.includes('docs.google.com')) {
+      Linking.openURL(req.url);
+      return false;
+    }
+    return true;
+  };
+
   return (
     <>
       <StatusBar style={themeState.color} />
@@ -33,6 +43,7 @@ function MainWebView() {
         <WebView
           source={{ uri: 'https://frolog.kr' }}
           onMessage={(event) => handleMessage(event)}
+          onShouldStartLoadWithRequest={(req) => handleExternalPage(req)}
         />
       </View>
     </>

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -1,0 +1,9 @@
+import { StatusBarStyle } from 'expo-status-bar';
+
+export const THEME_COLOR: {
+  [key: string]: { color: StatusBarStyle; bgColor: string };
+} = {
+  'bg-gray-300': { color: 'dark', bgColor: '#EDEEF4' },
+  white: { color: 'dark', bgColor: '#FFF' },
+  black: { color: 'light', bgColor: '#0E0E0E' },
+};


### PR DESCRIPTION
## 📍 작업 내용

> 상태바 style 이슈와 건의하기 페이지 상단이 상태바와 겹치는 이슈를 해결했습니다.

- [x] SafeArea 적용
- [x] WebView로 받은 theme 메세지 이용 동적으로 상태바 style 변경
- [x] iOS 환경에서 스와이프 뒤로가기 기능 구현

상태바 style 제어를 위해 useSafeAreaInsets를 이용해 기기의 상태바 높이를 구해 전체 view의 paddingTop을 해당 높이만큼 적용했습니다.
이후 WebView로 들어오는 메세지의 theme 정보를 이용해 View의 backgroundColor와 StatusBar의 style을 동적으로 변경시켰습니다.

건의하기 페이지는 헤더가 없는 페이지이기 해당 페이지로 접속했을 경우 다시 뒤로갈 수 있는 방법이 없었습니다.
때문에 별도의 외부 브라우저를 통해 열리도록 구현했습니다.

<br/>

## 📍 구현 결과 (선택)

![앱 상태바 변경](https://github.com/user-attachments/assets/7139c5ba-7003-433c-b019-a5c70e94a86b)

_앱 상태바 style 변경 Android_

![앱 건의하기](https://github.com/user-attachments/assets/b8835e79-8223-4a7e-9499-28a337d5375f)

_앱 건의하기 Android_
<br/>

## 📍 기타 사항

관련 Frolog_Web PR : [[Feat/#167]: WebView Theme 메세지 전달 구현](https://github.com/Team-Frolog/Frolog_Web/pull/168)

<br/>
