### PR TITLE
[Feat/#10]: google tag maneger 연결

### DIFF
--- a/src/components/MainWebView.tsx
+++ b/src/components/MainWebView.tsx
@@ -15,6 +15,9 @@ function MainWebView() {
   const [canGoBack, setCanGoBack] = useState<boolean>(false);
   const insets = useSafeAreaInsets();
 
+  const userAgent =
+    'Mozilla/5.0 (Linux; Android 10; Android SDK built for x86 Build/LMY48X) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/81.0.4044.117 Mobile Safari/608.2.11 WebView/1.0';
+
   useEffect(() => {
     const handleBack = () => {
       webViewRef.current?.goBack();
@@ -56,6 +59,7 @@ function MainWebView() {
       >
         <WebView
           ref={webViewRef}
+          userAgent={userAgent}
           source={{ uri: 'https://frolog.kr' }}
           onMessage={(event) => handleMessage(event)}
           onShouldStartLoadWithRequest={(req) => handleExternalPage(req)}


### PR DESCRIPTION
## 📍 작업 내용

> google tag maneger 연결을 위해 userAgent에 'WebView' 키워드를 추가했습니다.

```javascript
function() {
  let ua = navigator.userAgent;
  
  if (ua.includes("WebView")) {
    return "app_webview";
  } else if (/Mobile|Android|iPhone|iPad/i.test(ua)) {
    return "mobile_web";
  } else {
    return "desktop_web";
  }
}
```
google tag maneger 콘솔에 위와 같은 커스텀 함수를 추가해, 접속한 유저 기기의 userAgent를 파악해 GA에서 확인할 수 있게 구현했습니다.

<br/>

## 📍 구현 결과 (선택)



<br/>

## 📍 기타 사항


<br/>
